### PR TITLE
Bump compat, move options after the sequence in d/rules

### DIFF
--- a/src/ActInit.ml
+++ b/src/ActInit.ml
@@ -27,7 +27,7 @@ open OASISMessage
 open FileUtil
 open Common
 
-let dh_compat = "7"
+let dh_compat = "10"
 
 let run ~ctxt args =
 

--- a/src/Rules.ml
+++ b/src/Rules.ml
@@ -57,7 +57,7 @@ OCAMLFIND_LDCONF=ignore
 export OCAMLFIND_LDCONF
 
 %:
-	dh --with ocaml $@
+	dh $@ --with ocaml
 
 .PHONY: override_dh_auto_configure
 override_dh_auto_configure:


### PR DESCRIPTION
Hi,

In the generated `debian/` directory I bumped `d/compat` to 10 and fixed a minor thing in `d/rules`.